### PR TITLE
Upgrade DTFMTE to Python 3.12

### DIFF
--- a/DTFMTE.py
+++ b/DTFMTE.py
@@ -6,10 +6,6 @@ import argparse
 
 import re
 
-import codecs
-
-import string
-
 import os
 
 from datetime import datetime, timedelta
@@ -160,16 +156,17 @@ def main(argv=None):
             # infile = open(r'\\d1wrptfsrnp1\dev\APPS\DTC\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt','rb')
 
             infile = open(
-                filepath + 'DTC\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt', 'rb')
+                filepath + 'DTC\\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt',
+                'r',
+                encoding='utf-8'
+            )
 
             # print(infile)
 
             parse_stuff(infile, folder, out_file)
 
-        except IOError as (errno, strerror):
-
-            print
-            "I/O error({0}): {1}".format(errno, strerror)
+        except OSError as e:
+            print(f"I/O error({e.errno}): {e.strerror}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- modernize DTFMTE script for Python 3 by removing legacy imports and refactoring file handling
- open input files with UTF-8 encoding and improve error handling with `OSError`

## Testing
- `python -m py_compile DTFMTE.py DTFMTA.py DTFMTD.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68addff12420832791b3b8ee2c902e12