### PR TITLE
Upgrade DTFMTM to Python 3.12

### DIFF
--- a/DTFMTM.py
+++ b/DTFMTM.py
@@ -6,9 +6,6 @@ import argparse
 
 import re
 
-import codecs
-
-import string
 
 import os
 
@@ -65,7 +62,7 @@ def parse_stuff(infile, folder, outfile):
     if not os.path.exists(outfile + 'MTGO\\' + today):
         os.mkdir(outfile + 'MTGO\\' + today)
 
-    out_file = open(outfile + 'MTGO\\' + today + '\\' + folder + '.txt', 'w')
+    out_file = open(outfile + 'MTGO\\' + today + '\\' + folder + '.txt', 'w', encoding='utf-8')
 
     # r'\\d1wrptfsrprd3\reports\Firm10\MTGO\
 
@@ -160,16 +157,16 @@ def main(argv=None):
             # infile = open(r'\\d1wrptfsrnp1\dev\APPS\DTC\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt','rb')
 
             infile = open(
-                filepath + 'DTC\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt', 'rb')
+                filepath + 'DTC\\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt',
+                'r',
+                encoding='utf-8'
+            )
 
             # print(infile)
 
             parse_stuff(infile, folder, out_file)
-
-        except IOError as (errno, strerror):
-
-            print
-            "I/O error({0}): {1}".format(errno, strerror)
+        except OSError as e:
+            print(f"I/O error({e.errno}): {e.strerror}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- modernize DTFMTM by reading and writing UTF-8 text
- handle file access errors with `OSError` and f-strings

## Testing
- `python -m py_compile DTFMTM.py`


------
https://chatgpt.com/codex/tasks/task_e_68adea7872348327a2a7211ef6f44abf