### PR TITLE
Modernize DTFPDQ for Python 3.12

### DIFF
--- a/DTFPDQ.py
+++ b/DTFPDQ.py
@@ -6,10 +6,6 @@ import argparse
 
 import re
 
-import codecs
-
-import string
-
 import os
 
 from datetime import datetime, timedelta
@@ -65,7 +61,7 @@ def parse_stuff(infile, folder, outfile):
     if not os.path.exists(outfile + 'MTGO\\' + today):
         os.mkdir(outfile + 'MTGO\\' + today)
 
-    out_file = open(outfile + 'MTGO\\' + today + '\\' + folder + '.txt', 'w')
+    out_file = open(outfile + 'MTGO\\' + today + '\\' + folder + '.txt', 'w', encoding='utf-8')
 
     # r'\\d1wrptfsrprd3\reports\Firm10\MTGO\
 
@@ -160,16 +156,18 @@ def main(argv=None):
             # infile = open(r'\\d1wrptfsrnp1\dev\APPS\DTC\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt','rb')
 
             infile = open(
-                filepath + 'DTC\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt', 'rb')
+                filepath + r'DTC\DTFPART' + '\\' + folder + '\\' + folder + '_OUTPUT_' + yesterday_date + '.txt',
+                'r',
+                encoding='utf-8',
+            )
 
             # print(infile)
 
             parse_stuff(infile, folder, out_file)
 
-        except IOError as (errno, strerror):
+        except OSError as e:
 
-            print
-            "I/O error({0}): {1}".format(errno, strerror)
+            print(f"I/O error({e.errno}): {e.strerror}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- ensure DTFPDQ reads and writes text using UTF-8 and Python 3 APIs
- replace legacy IOError handling with modern `OSError` and f-strings
- clean up unused imports and binary file handling

## Testing
- `python -m py_compile DTFPDQ.py`


------
https://chatgpt.com/codex/tasks/task_e_68adeccafd308327aaa8fd94f2049b59