### PR TITLE
Ensure connections closed in calculate_slos

### DIFF
--- a/calculate_slos.py
+++ b/calculate_slos.py
@@ -66,60 +66,59 @@ def main() -> int:
         }
     )
 
-    process_date = datetime.strptime(args.process_date, "%Y-%m-%d")
-    slo_date = process_date + timedelta(days=1)
-    dow_int = process_date.weekday()
+    try:
+        process_date = datetime.strptime(args.process_date, "%Y-%m-%d")
+        slo_date = process_date + timedelta(days=1)
+        dow_int = process_date.weekday()
 
-    constant_name: str | None = None
+        constant_name: str | None = None
 
-    match dow_int:
-        case 4:
-            constant_name = "monthly_oe" if 15 <= process_date.day <= 21 else "friday"
-        case 0 | 1 | 2 | 3:
-            constant_name = "monday-thursday"
+        match dow_int:
+            case 4:
+                constant_name = "monthly_oe" if 15 <= process_date.day <= 21 else "friday"
+            case 0 | 1 | 2 | 3:
+                constant_name = "monday-thursday"
 
-    if constant_name is not None:
-        slos = apollo.query(
-            {
-                "query": (
-                    "select * from ConstantValueLookup where ApplicationName='batch_slo' "
-                    f"and ConstantName='{constant_name}'"
-                ),
-                "results": True,
-            }
-        )
-
-        for r in slos:
-            slo = f"{slo_date:%Y-%m-%d} {r[3]}"
-            result = batch.query(
+        if constant_name is not None:
+            slos = apollo.query(
                 {
                     "query": (
-                        "INSERT INTO batch.slos (process_date, slo) "
-                        f"VALUES ('{args.process_date}', '{slo}')"
+                        "select * from ConstantValueLookup where ApplicationName='batch_slo' "
+                        f"and ConstantName='{constant_name}'"
                     ),
-                    "results": False,
+                    "results": True,
                 }
             )
-            if result is not True:
-                print(
-                    f"calculate_slos.py: error: INSERT query failed with state: {result}"
-                )
-                apollo.close()
-                batch.close()
-                return 1
 
+            for r in slos:
+                slo = f"{slo_date:%Y-%m-%d} {r[3]}"
+                result = batch.query(
+                    {
+                        "query": (
+                            "INSERT INTO batch.slos (process_date, slo) "
+                            f"VALUES ('{args.process_date}', '{slo}')"
+                        ),
+                        "results": False,
+                    }
+                )
+                if result is not True:
+                    print(
+                        "calculate_slos.py: error: INSERT query failed with state:"
+                        f" {result}"
+                    )
+                    return 1
+
+            return 0
+
+        print(
+            "calculate_slos.py: error: either the process_date is on a weekend, "
+            "or something is very wrong with calculating ConstantName... input arguments: "
+            f"{args}"
+        )
+        return 1
+    finally:
         apollo.close()
         batch.close()
-        return 0
-
-    print(
-        "calculate_slos.py: error: either the process_date is on a weekend, "
-        "or something is very wrong with calculating ConstantName... input arguments: "
-        f"{args}"
-    )
-    apollo.close()
-    batch.close()
-    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- centralize database connection cleanup with a `try`/`finally` block in `calculate_slos`

## Testing
- `python -m py_compile calculate_slos.py`
- `python calculate_slos.py --help` *(fails: ModuleNotFoundError: No module named 'sql_console')*


------
https://chatgpt.com/codex/tasks/task_e_68af5edc11788327988426521d0d2c22