### PR TITLE
Ensure pymysql SqlWrapper respects database parameter

### DIFF
--- a/sql_console/sql_console/sql_console.py
+++ b/sql_console/sql_console/sql_console.py
@@ -92,12 +92,7 @@ class SqlWrapper:
         if method == 'pymssql':
             return self._connect_pymssql(credentials, database)
         if method == 'pymysql':
-            return pymysql.connect(
-                host=db[self.env][self.server],
-                user=credentials['user'],
-                password=credentials['password'],
-                autocommit=True,
-            )
+            return self._connect_pymysql(credentials, database)
         if method == 'psycopg2':
             return self._connect_psycopg2(credentials, database)
 
@@ -156,6 +151,18 @@ class SqlWrapper:
         if database:
             kwargs['database'] = database
         return pymssql.connect(**kwargs)
+
+    def _connect_pymysql(self, credentials: Dict[str, Any], database: str | None):
+        connection_kwargs = {
+            'host': db[self.env][self.server],
+            'user': credentials['user'],
+            'password': credentials['password'],
+            'autocommit': True,
+        }
+        if database:
+            connection_kwargs['database'] = database
+
+        return pymysql.connect(**connection_kwargs)
 
     def _connect_psycopg2(self, credentials: Dict[str, Any], database: str | None):
         if not database:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+root_str = str(ROOT)
+if root_str not in sys.path:
+    sys.path.insert(0, root_str)

--- a/tests/test_sql_console.py
+++ b/tests/test_sql_console.py
@@ -1,0 +1,51 @@
+from sql_console.sql_console import sql_console
+
+
+class DummyCursor:
+    description = None
+
+    def execute(self, *args, **kwargs):
+        pass
+
+    def fetchall(self):
+        return []
+
+    def nextset(self):
+        return False
+
+
+class DummyConnection:
+    def __init__(self, cursor_class):
+        self._cursor_class = cursor_class
+
+    def cursor(self, cursor_class):
+        assert cursor_class is self._cursor_class
+        return DummyCursor()
+
+    def close(self):
+        pass
+
+
+def test_pymysql_connection_uses_database(monkeypatch):
+    captured_kwargs = {}
+
+    def fake_connect(**kwargs):
+        captured_kwargs.update(kwargs)
+        return DummyConnection(sql_console.pymysql.cursors.DictCursor)
+
+    monkeypatch.setattr(sql_console.pymysql, 'connect', fake_connect)
+
+    wrapper = sql_console.SqlWrapper(
+        {
+            'env': 'prd',
+            'server': 'apollo',
+            'method': 'pymysql',
+            'db': 'Ale',
+            'credentials': {'user': 'user', 'password': 'pass'},
+        }
+    )
+
+    try:
+        assert captured_kwargs['database'] == 'Ale'
+    finally:
+        wrapper.close()


### PR DESCRIPTION
## Summary
- ensure the pymysql connection path in `SqlWrapper` forwards the selected database
- add a regression test covering the pymysql connection configuration
- add a pytest `conftest` so project modules import correctly from the test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ca9821148327bb31230804ffdb80